### PR TITLE
Added podLabels and podSecurityPolicy parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,16 @@ The following tables lists the main configurable parameters of the `deephealth-b
 | `backend.nodeSelector`                        | Node labels for pod assignment of the backend server replicas                                 |  `nil`                                        |
 | `backend.tolerations`                         | Tolerations labels for pod assignment of the backend server repliacas                         |  `nil`                                        |
 | `backend.affinity`                            | Affinity labels for pod assignment of the backend server replicas                             |  `nil`                                        |
+| `backend.podLabels`                           | Extra labels for backend pods                                                                 |  `nil`                                        |
+| `backend.podSecurityContext`                  | Backend pods' security context                                                                |  `nil`                                        |
 | `celery.acceptContent`                        | A list of comma-separated content-types to allow on Celery workers                            |  `json`                                       |
 | `celery.taskSerializer`                       | A list of comma-separated serializers to allow on Celery workers                              |  `json`                                       |
 | `celery.resources`                            | CPU/Memory resource requests/limits of the celery worker replicas                             |  `nil`                                        |
 | `celery.nodeSelector`                         | Node labels for pod assignment of the celery worker replicas                                  |  `nil`                                        |
 | `celery.tolerations`                          | Tolerations labels for pod assignment of the celery worker replicas                           |  `nil`                                        |
 | `celery.affinity`                             | Affinity labels for pod assignment of the celery worker replicas                              |  `nil`                                        |
+| `celery.podLabels`                            | Extra labels for celery pods                                                                  |  `nil`                                        |
+| `celery.podSecurityContext`                   | Celery pods' security context                                                                 |  `nil`                                        |
 | `broker.persistence.storageClass`             | Storage class used by RabbitMQ broker                                                         |  `*globalStorageClass`                        |
 | `broker.persistence.size`                     | Size of the datasets volume                                                                   |  `1Gi`                                        |
 | `postgresql.postgresqlPostgresPassword`       | PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)                  | _random 10 character alphanumeric string_     |

--- a/k8s/deephealth-backend/templates/backend-deployment.yaml
+++ b/k8s/deephealth-backend/templates/backend-deployment.yaml
@@ -21,7 +21,16 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "deephealth-backend.name" . }}-backend
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.backend.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- if .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- with .Values.backend.podSecurityContext }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
         - name: init
           image: "crs4/k8s-wait-for:latest"

--- a/k8s/deephealth-backend/templates/celery-deployment.yaml
+++ b/k8s/deephealth-backend/templates/celery-deployment.yaml
@@ -21,7 +21,16 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "deephealth-backend.name" . }}-celery
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.celery.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- if .Values.celery.podSecurityContext }}
+      securityContext:
+        {{- with .Values.celery.podSecurityContext }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
         - name: init
           image: "crs4/k8s-wait-for:latest"

--- a/k8s/deephealth-backend/templates/init-job.yaml
+++ b/k8s/deephealth-backend/templates/init-job.yaml
@@ -12,7 +12,20 @@ metadata:
     helm.sh/chart: {{ include "deephealth-backend.chart" . }}
 spec:
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "deephealth-backend.name" . }}-init-job
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.backend.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- if .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- with .Values.backend.podSecurityContext }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
         - name: wait-for-postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"

--- a/k8s/deephealth-backend/templates/upgrade-job.yaml
+++ b/k8s/deephealth-backend/templates/upgrade-job.yaml
@@ -15,7 +15,20 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "deephealth-backend.name" . }}-upgrade-job
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.backend.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- if .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- with .Values.backend.podSecurityContext }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       initContainers:
         - name: wait-for-postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"


### PR DESCRIPTION
In order to enable security features, i.e., networkPolicies and securityContexts, it was necessary to extend the Helm templates with additional parameters. The added parameters follow the bitnami Helm charts conventions. In particular:
 - A `podLabels` parameter allows to place custom labels in the deployed pods;
 - A `podSecurityContext` parameter allows to define securityContext rules for the deployed pods.